### PR TITLE
Modify default Mosaic over time

### DIFF
--- a/geogif/gif.py
+++ b/geogif/gif.py
@@ -316,6 +316,7 @@ def gif(
         append_images=imgs[1:],
         duration=1 / fps * 1000,  # ms
         loop=False,
+        disposal=2,
     )
     if to is None and isinstance(out, io.BytesIO):
         # second `isinstance` is just for the typechecker


### PR DESCRIPTION
# Current Behavior:
When creating gifs with arrays that contain Nans, each frame in the gif is a mosaic of all previous times. This comes from Pillow's default `disposal` parameter.

Here's an example with two frames, where the second frame is superposed over the first one:

<img src="https://github.com/user-attachments/assets/084437c2-f3f1-4473-a3cc-20144a0ffebb" width="500"/>

# Updated Behavior:
By explicitly setting `disposal=2`, previous frames are removed, and each frame contains only valid pixels corresponding to the labeled time:

<img src="https://github.com/user-attachments/assets/3e9cf3d8-36bc-4c09-9c95-2e18193d5955" width="500"/>

# Comments:
 My intuition would be that any reductions or aggregations would be done outside of the geogif function, and that we'd want the labeled time to correspond to the actual pixels being shown. But if this isn't the desired behavior, would it be OK to surface the `disposal` parameter in the `geogif.gif` function? I'd be happy to update the PR if that was the case.

Thank you! 